### PR TITLE
NOT TO MERGE - Add build files to be used as git subtree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,8 @@
 name: CI
 
 on:
-  pull_request:
   push:
-    branches:
-      - master
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,10 @@
 name: CI
 
 on:
+  pull_request:
   push:
     branches:
-      - "**"
-  pull_request:
-    branches:
-      - "**"
+      - master
 
 permissions:
   contents: read
@@ -16,43 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Test (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-
-    env:
-      BUILD_TYPE: Release
-      BUILD_DIR: build
-      GENERATOR: Ninja
-      CCACHE_DIR: ~/.ccache
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: |
-          ./scripts/deps.sh
-
-      - name: Restore ccache
-        uses: actions/cache@v4
-        with:
-          path: ~/.ccache
-          key: ccache-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
-          restore-keys: |
-            ccache-${{ runner.os }}-${{ github.ref_name }}-
-            ccache-${{ runner.os }}-
-
-      - name: Show ccache stats (before)
-        run: ccache -s || true
-
-      - name: Build + Test
-        run: make test
-
-      - name: Show ccache stats (after)
-        run: ccache -s || true
+  build:
+    uses: vivarium-ai/certifiable-github/.github/workflows/ci.yml@master
+    with:
+      build-target: certifiable-inference

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ export REVISION
 BUILD_DIR ?= build
 BUILD_TYPE ?= Release
 GENERATOR ?= Ninja
+PREFIX ?= /usr/local
 
 CMAKE ?= cmake
 CTEST ?= ctest
@@ -19,6 +20,15 @@ CTEST ?= ctest
 # ccache (enabled by default if available)
 CCACHE ?= ccache
 CCACHE_DIR ?= $(HOME)/.ccache
+
+# Export for scripts
+export BUILD_DIR
+export BUILD_TYPE
+export GENERATOR
+export PREFIX
+export CMAKE
+export CTEST
+export CCACHE
 export CCACHE_DIR
 
 CMAKE_CACHE_ARGS := \
@@ -26,35 +36,38 @@ CMAKE_CACHE_ARGS := \
 	-DCMAKE_C_COMPILER_LAUNCHER=$(CCACHE) \
 	-DCMAKE_CXX_COMPILER_LAUNCHER=$(CCACHE)
 
-.PHONY: all help deps config build test install release clean
+.PHONY: all help setup config build test install package release clean
 
 all: test
 
 ##@ Dependencies
-deps: ## Install project dependencies
-	./scripts/deps.sh
+setup: ## Setup project
+	./certifiable-build/scripts/setup.sh
 
 ##@ Development
 config: ## Configure the build
-	$(CMAKE) -S . -B $(BUILD_DIR) -G "$(GENERATOR)" $(CMAKE_CACHE_ARGS)
+	./certifiable-build/scripts/config.sh
 
 build: config ## Build the project
-	$(CMAKE) --build $(BUILD_DIR) --parallel
+	./certifiable-build/scripts/build.sh
 
 ##@ Testing
 test: build ## Run tests
-	$(CTEST) --test-dir $(BUILD_DIR) --output-on-failure
+	./certifiable-build/scripts/test.sh
 
 ##@ Project Management
 install: build ## Install the project
-	$(CMAKE) --install $(BUILD_DIR)
+	./certifiable-build/scripts/install.sh
 
-release: ## Build release artifacts
-	@echo "Building release..."
+package: ## Build release artifacts
+	./certifiable-build/scripts/package.sh
+
+release: ## Publish release artifacts
+	./certifiable-build/scripts/release.sh
 
 ##@ Maintenance
 clean: ## Remove all build artifacts
-	rm -rf $(EXES) $(DIST) $(BUILD_DIR)
+	./certifiable-build/scripts/clean.sh
 
 ##@ Documentation
 help: ## Display this help

--- a/certifiable-build/scripts/build.sh
+++ b/certifiable-build/scripts/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eu
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [BUILD_DIR]
+  BUILD_DIR: Build directory (env: BUILD_DIR, default: build)
+EOF
+  exit 1
+}
+
+BUILD_DIR="${1:-${BUILD_DIR:-build}}"
+CMAKE="${CMAKE:-cmake}"
+
+[ -d "$BUILD_DIR" ] || { echo "Build directory not found. Run config first."; exit 1; }
+
+echo "Building..."
+$CMAKE --build "$BUILD_DIR" --parallel

--- a/certifiable-build/scripts/clean.sh
+++ b/certifiable-build/scripts/clean.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [BUILD_DIR] [EXES] [DIST]
+  BUILD_DIR: Build directory (env: BUILD_DIR, default: build)
+  EXES:      Executables directory (env: EXES, optional)
+  DIST:      Distribution directory (env: DIST, optional)
+EOF
+  exit 1
+}
+
+BUILD_DIR="${1:-${BUILD_DIR:-build}}"
+EXES="${2:-${EXES:-}}"
+DIST="${3:-${DIST:-}}"
+
+echo "Cleaning build artifacts..."
+rm -rf "$BUILD_DIR"
+[ -n "$EXES" ] && rm -rf "$EXES"
+[ -n "$DIST" ] && rm -rf "$DIST"
+echo "Clean complete."

--- a/certifiable-build/scripts/config.sh
+++ b/certifiable-build/scripts/config.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -eu
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [BUILD_DIR] [BUILD_TYPE] [GENERATOR] [CCACHE]
+
+Positional args override env vars.
+
+  BUILD_DIR:   Build directory (env: BUILD_DIR, default: build)
+  BUILD_TYPE:  Build type (env: BUILD_TYPE, default: Release)
+  GENERATOR:   CMake generator (env: GENERATOR, default: Ninja if available else Unix Makefiles)
+  CCACHE:      Compiler cache command (env: CCACHE, default: ccache; set to "" or "false" to disable)
+  PREFIX:      Install prefix (env: PREFIX, default: /usr/local)
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+esac
+
+BUILD_DIR="${1:-${BUILD_DIR:-build}}"
+BUILD_TYPE="${2:-${BUILD_TYPE:-Release}}"
+GENERATOR="${3:-${GENERATOR:-Ninja}}"
+CCACHE="${4:-${CCACHE:-ccache}}"
+PREFIX="${PREFIX:-/usr/local}"
+CMAKE="${CMAKE:-cmake}"
+
+# Allow disabling ccache via CCACHE="" or CCACHE=false
+CCACHE_ARGS=""
+if [ -n "$CCACHE" ] && [ "$CCACHE" != "false" ] && command -v "$CCACHE" >/dev/null 2>&1; then
+  CCACHE_ARGS="-DCMAKE_C_COMPILER_LAUNCHER=$CCACHE -DCMAKE_CXX_COMPILER_LAUNCHER=$CCACHE"
+fi
+
+echo "Configuring: BUILD_DIR=$BUILD_DIR BUILD_TYPE=$BUILD_TYPE GENERATOR=$GENERATOR PREFIX=$PREFIX"
+
+# shellcheck disable=SC2086
+"$CMAKE" -S . -B "$BUILD_DIR" -G "$GENERATOR" \
+  -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+  $CCACHE_ARGS

--- a/certifiable-build/scripts/install.sh
+++ b/certifiable-build/scripts/install.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [BUILD_DIR] [PREFIX]
+  BUILD_DIR: Build directory (env: BUILD_DIR, default: build)
+  PREFIX:    Install prefix (env: PREFIX, default: /usr/local)
+EOF
+  exit 1
+}
+
+BUILD_DIR="${1:-${BUILD_DIR:-build}}"
+PREFIX="${2:-${PREFIX:-/usr/local}}"
+CMAKE="${CMAKE:-cmake}"
+
+[ -d "$BUILD_DIR" ] || { echo "Build directory not found. Run build first."; exit 1; }
+
+echo "Installing to $PREFIX..."
+$CMAKE --install "$BUILD_DIR" --prefix "$PREFIX"

--- a/certifiable-build/scripts/package.sh
+++ b/certifiable-build/scripts/package.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [BUILD_DIR] [VERSION] [REVISION]
+  BUILD_DIR: Build directory (env: BUILD_DIR, default: build)
+  VERSION:   Package version (env: VERSION, required)
+  REVISION:  Package revision (env: REVISION, required)
+EOF
+  exit 1
+}
+
+BUILD_DIR="${1:-${BUILD_DIR:-build}}"
+VERSION="${2:-${VERSION:-}}"
+REVISION="${3:-${REVISION:-}}"
+
+[ -z "$VERSION" ] && usage
+[ -z "$REVISION" ] && usage
+[ -d "$BUILD_DIR" ] || { echo "Build directory not found. Run build first."; exit 1; }
+
+echo "Creating package $VERSION-$REVISION..."
+# Add packaging logic here
+echo "Package created."

--- a/certifiable-build/scripts/release.sh
+++ b/certifiable-build/scripts/release.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eu
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [VERSION]
+  VERSION: Release version (env: VERSION, required)
+EOF
+  exit 1
+}
+
+VERSION="${1:-${VERSION:-}}"
+
+[ -z "$VERSION" ] && usage
+
+echo "Publishing release $VERSION..."
+# Add release logic here
+echo "Release published."

--- a/certifiable-build/scripts/setup.sh
+++ b/certifiable-build/scripts/setup.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 echo "Resolving system dependencies…"
 

--- a/certifiable-build/scripts/test.sh
+++ b/certifiable-build/scripts/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eu
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [BUILD_DIR]
+  BUILD_DIR: Build directory (env: BUILD_DIR, default: build)
+EOF
+  exit 1
+}
+
+BUILD_DIR="${1:-${BUILD_DIR:-build}}"
+CTEST="${CTEST:-ctest}"
+
+[ -d "$BUILD_DIR" ] || { echo "Build directory not found. Run build first."; exit 1; }
+
+echo "Running tests..."
+$CTEST --test-dir "$BUILD_DIR" --output-on-failure


### PR DESCRIPTION
This changeset is to illustrate the git subtree approach and to contrast with the equivalent build2 version before extracting into its own repo, but it is not intended to be merged.

Once the decision is made on whether to use build2, a new PR will be opened.